### PR TITLE
Add paired end option to sailfish

### DIFF
--- a/public/scala/src/org/broadinstitute/sting/queue/extensions/yeo_scripts/yeo/Sailfish.scala
+++ b/public/scala/src/org/broadinstitute/sting/queue/extensions/yeo_scripts/yeo/Sailfish.scala
@@ -6,10 +6,12 @@ import org.broadinstitute.sting.queue.function.CommandLineFunction
 
 class Sailfish extends CommandLineFunction {
   
-  
-  @Input(doc="input fastq file", shortName = "inFastq", fullName = "input_fastq_file", required = true) 
+  @Input(doc="input fastq file (Read 1)", shortName = "inFastq", fullName = "input_fastq_file", required = true) 
   var inFastq: File = _
-    
+
+  @Input(doc="input fastq pair file (Read 2)", shortName = "inFastqPair", fullName = "input_fastq_pair_file", required = false) 
+  var inFastqPair: File = _ 
+
   @Output(doc="output dir file", shortName = "outDir", fullName = "out_dir_file", required = true) 
   var outDir: File = _
   
@@ -19,17 +21,18 @@ class Sailfish extends CommandLineFunction {
   @Argument(doc="sh script to output", shortName = "shScript", fullName = "ash_script", required = false)
   var shScript: String = _
   
-  override def shortDescription = "sailfish"
-  this.nCoresRequest = Option(16)
+  override def shortDescription = "Run Sailfish k-mer counting based transcript quantification"
+  this.nCoresRequest = Option(8)
    
   def commandLine = "sailfish_quant.py" +
   required("-1", inFastq) +
+  optional("-2", inFastqPair) +
   required("--out-dir", outDir) +
   required("--index", index) +
   required("-n", shScript) +
   required("--out-sh", shScript) +
   required("-i", index) +
-  "-p 16 --do-not-submit && echo $(tail -n 2 " +
+  "-p 8 --do-not-submit && echo $(tail -n 2 " +
   required(shScript) +
   ") | bash"            
 }


### PR DESCRIPTION
I copied input code from `STAR.scala` to get the paired-end options. I also reduced the number of processors required so it doesn't need to wait for a full node (16 processors) to be free to run this, and can just run with 8 processors. 

* Addresses: https://github.com/YeoLab/gscripts/issues/54
* Will impact: https://github.com/YeoLab/gscripts/pull/55